### PR TITLE
Update README to refer to a prior version of joinmarket

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ scalar multiply (`ecmult`) and point addition (`ec_add_pubkeys`), into the
 ```
 git clone https://github.com/Joinmarket-Org/joinmarket-clientserver
 cd joinmarket-clientserver
+git checkout a612ddba72e8f79fff6fbc681c348172fdaa6544
 ./install.sh
 ```
 


### PR DESCRIPTION
The current build fails with the following error: I don't think this project is actively maintained so I just added a checkout to where I know it works. 

```
  File "rangeproof.py", line 291, in <module>
    run_test_rangeproof(value, rangebits)
  File "rangeproof.py", line 257, in run_test_rangeproof
    rp.generate_proof(proofval)
  File "rangeproof.py", line 57, in generate_proof
    pc = PC(encode(self.value, 256, minlen=32), blinding=self.gamma)
  File "/home/sanket1729/bulletproofs-poc/vectorpedersen.py", line 18, in __init__
    self.h = getNUMS(255).serialize() if not h else h
AttributeError: PublicKey instance has no attribute 'serialize'
```